### PR TITLE
Updates CI/CD workflow for .NET 8

### DIFF
--- a/.github/workflows/ci-and-deploy.yml
+++ b/.github/workflows/ci-and-deploy.yml
@@ -4,8 +4,11 @@ name: Test & Deploy to GitHub Pages
 on:
   push:
     branches:
-      - master     # change if your default branch is named differently
-
+      - master
+      
+permissions:
+  contents: write
+  
 env:
   PUBLISH_DIR: publish
 
@@ -19,7 +22,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Setup .NET SDK
-        uses: actions/setup-dotnet@v3
+        uses: actions/setup-dotnet@v4
         with:
           dotnet-version: '8.0.x'
 
@@ -35,7 +38,7 @@ jobs:
 
       - name: Upload test results
         if: always()
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: test-results
           path: TestResults/test-results.trx
@@ -51,7 +54,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Setup .NET SDK
-        uses: actions/setup-dotnet@v3
+        uses: actions/setup-dotnet@v4
         with:
           dotnet-version: '8.0.x'
 
@@ -63,7 +66,6 @@ jobs:
           touch ${{ env.PUBLISH_DIR }}/.nojekyll
 
       - name: Deploy to GitHub Pages
-        uses: peaceiris/actions-gh-pages@v3
-        with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          publish_dir: ${{ env.PUBLISH_DIR }}
+        uses: JamesIves/github-pages-deploy-action@v4
+        with:          
+          folder: ${{ env.PUBLISH_DIR }}                  

--- a/.idea/.idea.WebPage.Blazor/.idea/AndroidProjectSystem.xml
+++ b/.idea/.idea.WebPage.Blazor/.idea/AndroidProjectSystem.xml
@@ -1,6 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<project version="4">
-  <component name="AndroidProjectSystem">
-    <option name="providerId" value="RiderAndroidProjectSystem" />
-  </component>
-</project>


### PR DESCRIPTION
Updates the CI/CD workflow to use the latest versions of GitHub Actions.

- Updates the .NET SDK setup action to v4.
- Updates the artifact upload action to v4.
- Replaces the `peaceiris/actions-gh-pages` action with `JamesIves/github-pages-deploy-action` for GitHub Pages deployment.
- Adds permissions for contents to write to deploy GitHub Pages.