### PR TITLE
Updates giscus strict mode to non-strict

### DIFF
--- a/WebPage.Blazor/App/Entry/{slug}/Page.razor
+++ b/WebPage.Blazor/App/Entry/{slug}/Page.razor
@@ -128,7 +128,7 @@ else
             data-category="Announcements"
             data-category-id="DIC_kwDOOsvfVM4CqWfd"
             data-mapping="pathname"
-            data-strict="1"
+            data-strict="0"
             data-reactions-enabled="1"
             data-emit-metadata="0"
             data-input-position="top"


### PR DESCRIPTION
Changes the giscus strict mode setting to non-strict.

This allows for broader matching of discussions based on the pathname, improving user experience when discussions may not perfectly align with the page's URL.
