### PR TITLE
Updates giscus strict mode to non-strict

### DIFF
--- a/WebPage.Blazor/App/Entry/{slug}/Page.razor
+++ b/WebPage.Blazor/App/Entry/{slug}/Page.razor
@@ -1,4 +1,4 @@
-﻿@page "/Entry/{Slug}"
+﻿@page "/entry/{Slug}"
 @using WebPage.Blazor.Src.Domain.Metadata
 
 @inject WebPage.Blazor.Src.Services.LogPost.ILogPostService PostSvc


### PR DESCRIPTION
Changes the giscus strict mode setting to non-strict.

This allows for broader matching of discussions based on the pathname, improving user experience when discussions may not perfectly align with the page's URL.
