### PR TITLE
Updates giscus strict mode to non-strict

### DIFF
--- a/WebPage.Blazor/App/Entry/{slug}/Page.razor
+++ b/WebPage.Blazor/App/Entry/{slug}/Page.razor
@@ -19,10 +19,10 @@
   var shareUrl = $"{baseUri}/?entry={Uri.EscapeDataString(Slug)}";
 
 
-  <HeadOutlet>
+  <HeadContent>
     <meta name="giscus:backlink" content="@(shareUrl)">
     <meta property="og:title" content="@_t.Title">
-  </HeadOutlet>
+  </HeadContent>
 
 
   <head>


### PR DESCRIPTION
Changes the giscus strict mode setting to non-strict.

This allows for broader matching of discussions based on the pathname, improving user experience when discussions may not perfectly align with the page's URL.
